### PR TITLE
Enhance admin lookup with WvW details

### DIFF
--- a/src/gw2_api_client.py
+++ b/src/gw2_api_client.py
@@ -44,6 +44,9 @@ class GW2ApiClient:
 
     def world(self):
         world_id = self.account()["world"]
+        return self.world_by_id(world_id)
+
+    def world_by_id(self, world_id):
         ping_url = self.url + f"/worlds?id={world_id}"
         response = requests.get(ping_url, headers=self.headers)
 


### PR DESCRIPTION
## Summary
- include WvW information such as rank, commander status, and world details for each account shown in /admin_lookup
- add a reusable client helper for fetching world metadata by id so the command can resolve world names and populations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69126c7f9198832facaab7c7ad90fd98)